### PR TITLE
make KeplerPORT python 3 compatible

### DIFF
--- a/KeplerPORTs.py
+++ b/KeplerPORTs.py
@@ -928,6 +928,6 @@ if __name__ == "__main__":
     plt.savefig(wantFigure+'.eps',bbox_inches='tight')
     plt.show()
     
-    print "We Will Miss You Kepler!"
+    print("We Will Miss You Kepler!")
 
 


### PR DESCRIPTION
This PR makes KeplerPORT able to be executed in a Python 3.x environment.